### PR TITLE
Parse more valid prometheus strings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: rust:1.42-slim-buster
+      - image: rust:1.56-slim-buster
     steps:
       - checkout
       - run:
@@ -19,7 +19,7 @@ jobs:
 
   publish:
     docker:
-      - image: rust:1.42-slim-buster
+      - image: rust:1.56-slim-buster
     steps:
       - checkout
       - run:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  open-pull-requests-limit: 25
+  directory: /
+  registries: []
+  schedule:
+    interval: daily

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ circle-ci = { repository = "HewlettPackard/prometheus-parser-rs", branch = "mast
 
 [dependencies]
 pest = "2.1"
-pest_consume = "1.0"
+pest_consume = "1.1"
 pest_derive = "2.1"
-pest_consume_macros = "1.0"
-enquote = "1.0"
+pest_consume_macros = "1.1"
+enquote = "1.1"
 lazy_static = "1"
 
 [dev-dependencies]

--- a/src/prometheus.pest
+++ b/src/prometheus.pest
@@ -209,11 +209,11 @@ expression = {
 duration_value = ${ ASCII_DIGIT+ }
 duration_unit = ${ "s" | "m" | "h" | "d" | "w" | "y" }
 
-// allow 1, 1.0, -1, -1.0, .1, -.1 but don't allow empty / '.' / '-' / '-.'
+// allow 1, 1.0, -1, -1.0, .1, -.1, 1e1, -1e1, 1e-1, -1e-1 but don't allow empty / '.' / '-' / '-.'
 signed_float = @{
   ("+" | "-")? ~ (
     ("Inf" | "NaN") |
-    (ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)?) |
+    (ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?) |
     ("." ~ ASCII_DIGIT+)
   )
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -504,3 +504,43 @@ fn parse_weird_floats() -> Result<()> {
 
   Ok(())
 }
+
+#[test]
+fn parse_scientific_notation_floats() -> Result<()> {
+    match parse_expr("1e1")? {
+      Expression::Float(f) => assert_eq!(f, (1e1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("1e-1")? {
+      Expression::Float(f) => assert_eq!(f, (1e-1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("-1e1")? {
+      Expression::Float(f) => assert_eq!(f, (-1e1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("-1e-1")? {
+      Expression::Float(f) => assert_eq!(f, (-1e-1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("1.0e1")? {
+      Expression::Float(f) => assert_eq!(f, (1.0e1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("1e01")? {
+      Expression::Float(f) => assert_eq!(f, (1e01 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("1E01")? {
+      Expression::Float(f) => assert_eq!(f, (1e01 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
Prometheus allows a variety of syntaxes for string literals: 
https://prometheus.io/docs/prometheus/latest/querying/basics/#string-literals. 
Previously only the double quote one was supported. This adds support for
single quotes. There is also the backtick syntax that handles escaping
differently. I don't think that one is as common so have left it our for
now.

I've also merged the upstream master branch as there have been a few commits
since I forked it. The changes I'm making are in f6df03b99296f45116ee32435c8699f47f89a6c9.